### PR TITLE
Add rector plugin

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -12,3 +12,4 @@ repositories:
       - phpcq/plugin-phpunit
       - phpcq/plugin-psalm
       - phpcq/plugin-deptrac
+      - phpcq/plugin-rector


### PR DESCRIPTION
It's time to get the next awesome tool integrated into PHPCQ. The [plugin-rector](https://github.com/phpcq/plugin-rector) provides [rector](https://github.com/rectorphp/rector) integration for PHPCQ.