### PR TITLE
Add doctrine coding standard plugin

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -13,3 +13,4 @@ repositories:
       - phpcq/plugin-psalm
       - phpcq/plugin-deptrac
       - phpcq/plugin-rector
+      - phpcq/plugin-doctrine-coding-standard


### PR DESCRIPTION
This adds https://github.com/phpcq/plugin-doctrine-coding-standard as a new plugin