### PR TITLE
Also override php version to 8.2+ for psalm 6.9.x

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -4,6 +4,30 @@ repositories:
     type: tool-static
     tools:
       psalm:
+        - version: 6.9.0
+          requirements:
+            php:
+              php: ~8.2.27 || ~8.3.16 || ~8.4.3
+        - version: 6.9.2
+          requirements:
+            php:
+              php: ~8.2.27 || ~8.3.16 || ~8.4.3
+        - version: 6.9.3
+          requirements:
+            php:
+              php: ~8.2.27 || ~8.3.16 || ~8.4.3
+        - version: 6.9.4
+          requirements:
+            php:
+              php: ~8.2.27 || ~8.3.16 || ~8.4.3
+        - version: 6.9.5
+          requirements:
+            php:
+              php: ~8.2.27 || ~8.3.16 || ~8.4.3
+        - version: 6.9.6
+          requirements:
+            php:
+              php: ~8.2.27 || ~8.3.16 || ~8.4.3
         - version: 6.10.0
           requirements:
             php:


### PR DESCRIPTION
Note that version 6.9.1 is missing as it does not seem to exist - might have been pulled back?