### PR TITLE
Correct minimum php version vor psalm 6.13.0 and 6.13.0

### DIFF
--- a/sources.yaml
+++ b/sources.yaml
@@ -86,6 +86,14 @@ repositories:
           requirements:
             php:
               php: ~8.2.27 || ~8.3.16 || ~8.4.3
+        - version: 6.13.0
+          requirements:
+            php:
+              php: ~8.2.27 || ~8.3.16 || ~8.4.3
+        - version: 6.13.1
+          requirements:
+            php:
+              php: ~8.2.27 || ~8.3.16 || ~8.4.3
 
   plugin-github:
     type: plugin-github


### PR DESCRIPTION
These also suffer from https://github.com/vimeo/psalm/issues/11423